### PR TITLE
Fix links on home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -45,18 +45,18 @@ layout: default
         <p>Instrukcja jak dostać termin wylistowany na stronach, masz trzy opcje:</p>
 
         <ol>
-            <li> Profil zaufany https://pacjent.erejestracja.ezdrowie.gov.pl/  - najprostsze i najszybsze (można założyć tymczasowy profil zaufany ważny 3 miesiące, można to zrobić online, potrzebna jest kamerka - urzędnik będzie dzwonił, trzeba będzie mu pokazać dowód osobisty i siebie), oprócz tego można logować sie też nowym dowodem (tym z PINem) lub mojeID.</li>
+            <li> <a href="https://pacjent.erejestracja.ezdrowie.gov.pl/">Profil zaufany</a>  - najprostsze i najszybsze (można założyć tymczasowy profil zaufany ważny 3 miesiące, można to zrobić online, potrzebna jest kamerka - urzędnik będzie dzwonił, trzeba będzie mu pokazać dowód osobisty i siebie), oprócz tego można logować sie też nowym dowodem (tym z PINem) lub mojeID.</li>
 
             <li> Dzwonisz na 989 i prosisz konsultanta o termin pod podanym adresem (może być potrzebny kod pocztowy).</li>
 
-            <li> Wchodzisz na https://www.gov.pl/web/szczepimysie/mapa-punktow-szczepien#/ znajdujesz punkt szczepień po adresie, dzwonisz na podany numer telefonu.</li>
+            <li> Wchodzisz na <a href="https://www.gov.pl/web/szczepimysie/mapa-punktow-szczepien#/">mapę punktów szczepień</a> znajdujesz punkt szczepień po adresie, dzwonisz na podany numer telefonu.</li>
             <ol>
 
                 <p>Info które nie było podane w mediach: <strong>Pfizer i Moderna jest dostępny dla wszystkich (od 1 kwietnia) którzy mają skierowanie</strong></p>
 
                 <p>Skierowania są wydawane automatycznie, 1 kwietnia skierowania dostały osoby 40+, 50+ które wyraziły chęć szczepienia w styczniu-marcu na specjalnej stronie (już niedostępnej).</p>
 
-                <p>Możesz sprawdzić czy masz skierowanie za pomocą [erejestracji](https://pacjent.erejestracja.ezdrowie.gov.pl/)</p>
+                <p>Możesz sprawdzić czy masz skierowanie za pomocą <a href="https://pacjent.erejestracja.ezdrowie.gov.pl/">erejestracji</a></p>
 
                 <strong>Masz rodziców umówionych na AstraZenece? Możesz ich przepisać na Pfizera/Modernę.</strong>
 


### PR DESCRIPTION
Should now be displayed properly like `zgłoś`:
![image](https://user-images.githubusercontent.com/13603158/116201572-eca2d180-a739-11eb-8855-b7446538c2f7.png)
