### PR TITLE
Dodanie sekcji FAQ na stronie głównej

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -63,6 +63,20 @@ layout: default
             -->
 </div>
 
+<hr>
+
+<p>
+  <strong>Często zadawane pytania </strong>
+  <p>Sporo informacji na temat szczepień oraz szczepionek można znaleźć na stronie rządowej <a href="https://www.gov.pl/web/szczepimysie/pytania-i-odpowiedzi">https://www.gov.pl/web/szczepimysie/pytania-i-odpowiedzi</a></p>
+  <p>Poniżej natomiast znajdują się odpowiedzi na pytania specyficzne dla strony szczepienia.github.io:</p>
+  <p><strong>Pyt: Wyszukiwarka pokazuje wolne terminy, natomiast gdy chcę się zapisać poprzez e-rejestrację, takie terminy nie zostają odnalezione (lub dzwoniąc na infolinię/do punktu szczepień otrzymuję informację, że terminy te nie są dostępne). Dlaczego tak się dzieje?</strong></p>
+  <p>Odp: Najprawdopodobniej ktoś inny zdążył już zarejestrować się na dany termin. Wynika to z faktu, iż wyszukiwarka nie wyświetla danych na żywo, lecz odświeża je co pewien czas. Czas od ostatniej aktualizacji widnieje na górze strony.</p>
+  <p><strong>Pyt: Moje miasto zniknęło z wyszukiwarki</strong></p>
+  <p>Odp: Niestety prawdopodobnie oznacza to, iż na chwilę obecną nie ma wolnych terminów dla danej miejscowości. Warto poczekać do następnej aktualizacji (lub nawet kilku następnych) - jeżeli tylko pojawią się nowe terminy, będą one widoczne.<br /> Jeżeli natomiast problem występowałby przez dłuższy czas, można zgłosić to <a href="https://github.com/szczepienia/szczepienia.github.io/issues">w tym miejscu</a></p>
+</p>
+
+<hr>
+
 <p>
 Jeśli masz jakieś uwagi (ale błagam, nie prośby o dodanie miast, niestety nadal nie mogę więcej dodać ☹) to <a href="https://github.com/szczepienia/szczepienia.github.io/issues">zgłoś</a> (lub daj znać na <a href="https://twitter.com/krzyk">twitterze</a> lub na wykopie).
 </p>


### PR DESCRIPTION
Pomyślałem, że dobrym pomysłem byłoby dodanie na stronie głównej sekcji z odpowiedziami na często zadawane pytania, dzięki czemu użytkownicy mogliby uniknąć skonfundowania np. z powodu rozbieżności pomiędzy danymi prezentowanymi na stronie, a rzeczywistością. Dodatkowo zmniejszyłoby to liczbę powtarzających się issues. Co myślisz o czymś takim?